### PR TITLE
Resolve "Potassium.init() must return a dictionary"

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,6 +57,8 @@ def init():
 
     modules.script_callbacks.app_started_callback(None, app_fastapi)
     register_model(model=model)
+    
+    return {}
 
 @app.handler(route="/txt2img")
 def handler(context: dict, request: Request) -> Response:


### PR DESCRIPTION
Building in Banana breaks at this error. This fix resolves it, tested on Banana.